### PR TITLE
Make logging each received and sent message optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # minichord
+
 Message specification for the Chord assignment at Reykjavik University
+
+tag v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/almarbjornsson/minichord
+module github.com/mkyas/minichord
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mkyas/minichord
+module github.com/almarbjornsson/minichord
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/message.go
+++ b/message.go
@@ -10,6 +10,22 @@ import (
 
 const I64SIZE = 8
 
+
+// LoggingEnabled controls whether logs should be printed.
+var LoggingEnabled = true
+
+// logf is a helper function that logs formatted output if LoggingEnabled is true.
+func logf(format string, v ...interface{}) {
+	if LoggingEnabled {
+		log.Printf(format, v...)
+	}
+}
+
+func UseLogging(enabled bool) {
+	LoggingEnabled = enabled
+}
+
+
 // ReceiveMiniChordMessage receives a protobuf marshaled message on
 // a connection conn and unmarshals it.
 // Make sure to call this function from only one go routine at a time.
@@ -52,8 +68,7 @@ func ReceiveMiniChordMessage(conn net.Conn) (message *MiniChord, err error) {
 			data, err)
 		return
 	}
-	log.Printf("ReceiveMiniChordMessage(): received %s (%v), %d from %s\n",
-		message, data[:length], length, conn.RemoteAddr().String())
+	logf("ReceiveMiniChordMessage(): received %s, %d from %s\n", message, length, conn.RemoteAddr().String())
 	return
 }
 
@@ -61,8 +76,7 @@ func ReceiveMiniChordMessage(conn net.Conn) (message *MiniChord, err error) {
 // a connection conn.
 func SendMiniChordMessage(conn net.Conn, message *MiniChord) (err error) {
 	data, err := proto.Marshal(message)
-	log.Printf("SendMiniChordMessage(): sending %s (%v), %d to %s\n",
-		message, data, len(data), conn.RemoteAddr().String())
+	logf("SendMiniChordMessage(): sending %s, %d to %s\n", message, len(data), conn.RemoteAddr().String())
 	if err != nil {
 		log.Panicln("Failed to marshal message.", err)
 	}


### PR DESCRIPTION
To speed up sending and receiving, you can now disable logging. Error messages are still printed.


Sending 10k+ packets per node, and printing each one, adds up quickly and results in huge delays in the network.




Just so you know, I am not a go expert, I didn't find an easy way to disable the printing without modifying the module.